### PR TITLE
Change adding handler code.

### DIFF
--- a/src/nipplejs.js
+++ b/src/nipplejs.js
@@ -133,9 +133,9 @@ var Nipple = function (options) {
 };
 
 // Basic event system.
-Nipple.prototype.on = function (type, cb) {
+Nipple.prototype.on = function (arg, cb) {
     var self = this;
-    var types = type.split(/[ ,]+/g);
+    var types = arg.split(/[ ,]+/g);
     var type;
 
     for (var i = 0; i < types.length; i += 1) {

--- a/src/nipplejs.js
+++ b/src/nipplejs.js
@@ -135,17 +135,14 @@ var Nipple = function (options) {
 // Basic event system.
 Nipple.prototype.on = function (type, cb) {
     var self = this;
-    var types = type.split(/[ ,]/g);
+    var types = type.split(/[ ,]+/g);
+    var type;
 
-    if (types.length > 1) {
-        for (var i = 0, max = types.length; i < max; i += 1) {
-            self.on(types[i], cb);
-        }
-        return self;
+    for (var i = 0; i < types.length; i += 1) {
+        type = types[i];
+        self.handlers[type] = self.handlers[type] || [];
+        self.handlers[type].push(cb);
     }
-
-    self.handlers[type] = self.handlers[type] || [];
-    self.handlers[type].push(cb);
     return self;
 };
 


### PR DESCRIPTION
I noticed that if you had multiple spaces in the event string it added a too `handlers[""]`

eg:
```javascript
joystick.on("start         end move", function(event) {
    ...
});
```
resulted in:
```javascript
Object {start: Array[1], "": Array[8], end: Array[1], move: Array[1]}
```