### PR TITLE
Add a destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Your manager has the following signature :
     on: Function,
     off: Function,
     get: Function, // get a specific joystick
+    destroy: Function,
     options: {
         zone: Element,
         multitouch: Boolean,
@@ -162,6 +163,14 @@ An helper to get an instance via its identifier.
 ```javascript
 // Will return the nipple instanciated by the touch identified by 0
 manager.get(0);
+```
+
+#### `manager.destroy()`
+
+Gently remove all nipples from the DOM and unbind all events.
+
+```javascript
+manager.destroy();
 ```
 
 ### nipple instance (joystick)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Each joystick has the following signature :
     hide: Function,         // fade-out
     add: Function,          // inject into dom
     remove: Function,       // remove from dom
+    destroy: Function,
     identifier: Number,
     trigger: Function,
     position: {             // position of the center
@@ -239,6 +240,10 @@ Add the joystick's element to the dom.
 ### `joystick.remove()`
 
 Remove the joystick's element from the dom.
+
+### `joystick.destroy()`
+
+Gently remove this nipple from the DOM and unbind all related events.
 
 ### `joystick.identifier`
 
@@ -411,6 +416,12 @@ Will pass the instance alongside the event.
 #### `hidden`
 
 Is triggered at the end of the fade-out animation.
+
+Will pass the instance alongside the event.
+
+#### `destroyed`
+
+Is trigger at the end of destroy.
 
 Will pass the instance alongside the event.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ manager.on('event#1 event#2', function (evt, data) {
 Note that you can listen to multiple events at once by separating
 them either with a space or a comma (or both, I don't care).
 
-#### `manager.off(type [, handler])`
+#### `manager.off([type, handler])`
 
 To remove an event handler :
 
@@ -151,7 +151,9 @@ To remove an event handler :
 manager.off('event', handler);
 ```
 
-If you don't specify the handler, all handlers for that type will be removed.
+If you call off without arguments, all handlers will be removed.
+
+If you don't specify the handler but just a type, all handlers for that type will be removed.
 
 #### `manager.get(identifier)`
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -12,6 +12,7 @@ var Manager = function (options) {
     self.nipples.on = self.on.bind(self);
     self.nipples.off = self.off.bind(self);
     self.nipples.options = self.options;
+    self.nipples.destroy = self.destroy.bind(self);
     self.nipples.get = function (id) {
         for (var i = 0, max = self.nipples.length; i < max; i += 1) {
             if (self.nipples[i].identifier === id) {
@@ -278,4 +279,15 @@ Manager.prototype.ondestroyed = function(evt, nipple) {
     if (nipple) {
         this.nipples.splice(this.nipples.indexOf(nipple), 1);
     }
+};
+
+// Cleanly destroy the manager
+Manager.prototype.destroy = function () {
+    this.unbindEvt(this.options.zone, 'start');
+    this.unbindEvt(document, 'move');
+    this.unbindEvt(document, 'end');
+    this.nipples.forEach(function(nipple) {
+        nipple.destroy();
+    });
+    this.off();
 };

--- a/src/manager.js
+++ b/src/manager.js
@@ -7,6 +7,7 @@ var Manager = function (options) {
     self.config(options);
     self.nipples = [];
     self.bindEvt(self.options.zone, 'start');
+    self.on('destroyed', this.ondestroyed);
 
     self.nipples.on = self.on.bind(self);
     self.nipples.off = self.off.bind(self);
@@ -269,4 +270,12 @@ Manager.prototype.processOnEnd = function (evt) {
     self.trigger('end ' + identifier + ':end', nipple);
     var index = self.nipples.indexOf(nipple);
     self.nipples.splice(index, 1);
+};
+
+// Remove destroyed nipple from the list
+Manager.prototype.ondestroyed = function(evt, nipple) {
+    nipple = this.nipples.get(nipple.identifier);
+    if (nipple) {
+        this.nipples.splice(this.nipples.indexOf(nipple), 1);
+    }
 };

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -20,6 +20,7 @@ var Nipple = function (manager, options) {
         hide: this.hide.bind(this),
         add: this.addToDom.bind(this),
         remove: this.removeFromDom.bind(this),
+        destroy: this.destroy.bind(this),
         computeDirection: this.computeDirection.bind(this),
         trigger: this.trigger.bind(this),
         position: this.position,
@@ -134,6 +135,16 @@ Nipple.prototype.addToDom = function () {
 Nipple.prototype.removeFromDom = function () {
     this.manager.options.zone.removeChild(this.ui.el);
     return this;
+};
+
+// Entirely destroy this nipple
+Nipple.prototype.destroy = function () {
+    clearTimeout(this.removeTimeout);
+    clearTimeout(this.showTimeout);
+    this.off();
+    this.removeFromDom();
+    this.trigger('destroyed', this);
+    this.manager.trigger('destroyed ' + this.identifier + ':destroyed', this);
 };
 
 // Fade in the Nipple instance.

--- a/src/super.js
+++ b/src/super.js
@@ -22,8 +22,10 @@ Super.prototype.on = function (arg, cb) {
 
 Super.prototype.off = function (type, cb) {
     var self = this;
-    if (cb === undefined) {
-        self.handlers[type] = [];
+    if (type === undefined) {
+        self.handlers = {};
+    } else if (cb === undefined) {
+        self.handlers[type] = null;
     } else if (self.handlers[type] && self.handlers[type].indexOf(cb) >= 0) {
         self.handlers[type].splice(self.handlers[type].indexOf(cb), 1);
     }


### PR DESCRIPTION
Created manager never unbind for events and do not expose unbind. This PR aims to fix this.

A public destroy method is a good way to let user create then clearing a view (I think about view as a Backbone.Marionette user, but it's the same for React, Ember, ...), then go back, re-create, etc, safely, without memory leak or issues due to events.

Related to #6 
