### PR TITLE
fix(nipple): use `document.body.contains` for IE11 doesn't shortcut

### DIFF
--- a/src/nipple.js
+++ b/src/nipple.js
@@ -150,7 +150,7 @@ Nipple.prototype.applyStyles = function (styles) {
 // Inject the Nipple instance into DOM.
 Nipple.prototype.addToDom = function () {
     // We're not adding it if we're dataOnly or already in dom.
-    if (this.options.dataOnly || document.contains(this.ui.el)) {
+    if (this.options.dataOnly || document.body.contains(this.ui.el)) {
         return;
     }
     this.manager.options.zone.appendChild(this.ui.el);
@@ -159,7 +159,7 @@ Nipple.prototype.addToDom = function () {
 
 // Remove the Nipple instance from DOM.
 Nipple.prototype.removeFromDom = function () {
-    if (this.options.dataOnly || !document.contains(this.ui.el)) {
+    if (this.options.dataOnly || !document.body.contains(this.ui.el)) {
         return;
     }
     this.manager.options.zone.removeChild(this.ui.el);


### PR DESCRIPTION
close #17 by using `document.body.contains` instead of assuming that the browser will shortcut for us.