### PR TITLE
Add missing 'main' property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "version": "0.6.7",
   "name": "nipplejs",
+  "main": "./dist/nipplejs.js",
   "homepage": "https://github.com/yoannmoinet/nipplejs",
   "author": "Yoann Moinet <yoann.moinet@gmail.com>",
   "description": "A virtual joystick for touch capable interfaces",


### PR DESCRIPTION
This will allow `wiredep` and other tools to automatically inject nipplejs into source code.