### PR TITLE
Update README to point to safe-for-work fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 ![Bower](https://img.shields.io/bower/v/nipplejs.svg)
 [![npm](https://img.shields.io/npm/dm/nipplejs.svg)](https://npmjs.org/package/nipplejs)
 
+Looking for a version of this library with a more work-appropriate name? Check out [ThumbstickJS](https://github.com/lazerwalker/thumbstick).
+
 # Table Of Contents
 <details>
 


### PR DESCRIPTION
At your recommendation in #80, I've forked this library to change the name. It might be nice to explicitly point folks my way who are also looking for a joystick library whose name is a bit more appropriate for professional workplace use?