### PR TITLE
Show raw data on move

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ Three modes are possible :
 - new joystick is created at each new touch farther than `options.catchDistance` of any previously created joystick.
 - the joystick is faded-out when released but not destroyed.
 - when touch is made **inside** the `options.catchDistance` a new direction is triggered immediately.
-- when touch is made **oustide** the `options.catchDistance` the previous joystick is destroyed and a new one is created.
+- when touch is made **outside** the `options.catchDistance` the previous joystick is destroyed and a new one is created.
 - **cannot** be multitouch.
 
 #### `'static'`
-- a joystick is positionned immediately at `options.position`.
+- a joystick is positioned immediately at `options.position`.
 - one joystick per zone.
 - each new touch triggers a new direction.
 - **cannot** be multitouch.
@@ -289,7 +289,7 @@ Your manager has the following signature :
 
 #### `manager.on(type, handler)`
 
-If you whish to listen to internal events like :
+If you wish to listen to internal events like :
 
 ```javascript
 manager.on('event#1 event#2', function (evt, data) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -228,6 +228,7 @@ Collection.prototype.pressureFn = function (touch, nipple, identifier) {
 Collection.prototype.onstart = function (evt) {
     var self = this;
     var opts = self.options;
+    var origEvt = evt;
     evt = u.prepareEvent(evt);
 
     // Update the box position
@@ -238,6 +239,22 @@ Collection.prototype.onstart = function (evt) {
         // meaning we don't have more active nipples than we should.
         if (self.actives.length < opts.maxNumberOfNipples) {
             self.processOnStart(touch);
+        }
+        else if(origEvt.type.match(/^touch/)){
+            // zombies occur when end event is not received on Safari
+            // first touch removed before second touch, we need to catch up...
+            // so remove where touches in manager that no longer exist
+            Object.keys(self.manager.ids).forEach(function(k){
+                if(Object.values(origEvt.touches).findIndex(function(t){return t.identifier===k;}) < 0){
+                    // manager has id that doesn't exist in touches
+                    var e = [evt[0]];
+                    e.identifier = k;
+                    self.processOnEnd(e);
+                }
+            });
+            if(self.actives.length < opts.maxNumberOfNipples){
+                self.processOnStart(touch);
+            }
         }
     };
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -366,6 +366,11 @@ Collection.prototype.processOnMove = function (evt) {
     var rAngle = u.radians(angle);
     var force = dist / size;
 
+    var raw = {
+        dist: dist,
+        pos: pos
+    };
+
     // If distance is bigger than nipple's size
     // we clamp the position.
     if (dist > size) {
@@ -403,6 +408,7 @@ Collection.prototype.processOnMove = function (evt) {
             radian: rAngle,
             degree: angle
         },
+        raw: raw,
         instance: nipple,
         lockX: opts.lockX,
         lockY: opts.lockY

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -282,9 +282,9 @@ export class JoystickManager {
 }
 
 export interface Collection {
-    nipples: [];
-    idles: [];
-    actives: [];
+    nipples: any[];
+    idles: any[];
+    actives: any[];
     ids: number[];
     pressureIntervals: {};
     manager: JoystickManager;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -159,6 +159,10 @@ export interface JoystickOutputData {
         x: string;
         y: string;
     };
+    raw: {
+      dist: number;
+      pos: Position;
+    };
     distance: number;
     force: number;
     identifier: number;


### PR DESCRIPTION
1. adds `any` type for implicitly typed arrays, otherwise there is a compile error using typescript 2.8.4
2. add raw data needed for using nipplejs data-only as touchpad event basis
3. fix zombies on safari when touchend is not triggered by first touch ending while second touch still down.  

That is, zombies were occurring during the following series of events:
touch start:1 followed by touch move:1 followed by touch start:2 followed by touch end:1
After touch end:2, no new nipple could be created, and nipple 1 was never destroyed.  This was an endless lockup, that we also observed in the demo site, in any mode.