### PR TITLE
Add an options to use with dynamic pages, fixes #120

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ var options = {
     lockY: Boolean,                 // only move on the Y axis
     catchDistance: Number,          // distance to recycle previous joystick in
                                     // 'semi' mode
-    dynamic_page: Boolean,          // Enable if the page has dynamically visible elements
+    dynamicPage: Boolean,          // Enable if the page has dynamically visible elements
 };
 ```
 
@@ -253,7 +253,7 @@ Locks joystick's movement to the x (horizontal) axis
 ### `options.lockY` defaults to false
 Locks joystick's movement to the y (vertical) axis
 
-### `options.dynamic_page` defaults to true
+### `options.dynamicPage` defaults to true
 Enable if the page has dynamically visible elements such as for Vue, React, Angular or simply some CSS hiding or showing some DOM.
 
 ----

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ var options = {
     restOpacity: Number,            // opacity when not 'dynamic' and rested
     lockX: Boolean,                 // only move on the X axis
     lockY: Boolean,                 // only move on the Y axis
-    catchDistance: Number           // distance to recycle previous joystick in
+    catchDistance: Number,          // distance to recycle previous joystick in
                                     // 'semi' mode
+    dynamic_page: Boolean,          // Enable if the page has dynamically visible elements
 };
 ```
 
@@ -252,6 +253,8 @@ Locks joystick's movement to the x (horizontal) axis
 ### `options.lockY` defaults to false
 Locks joystick's movement to the y (vertical) axis
 
+### `options.dynamic_page` defaults to true
+Enable if the page has dynamically visible elements such as for Vue, React, Angular or simply some CSS hiding or showing some DOM.
 
 ----
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -33,7 +33,8 @@ function Collection (manager, options) {
         restJoystick: true,
         restOpacity: 0.5,
         lockX: false,
-        lockY: false
+        lockY: false,
+        dynamic_page: false
     };
 
     self.config(options);
@@ -375,6 +376,15 @@ Collection.prototype.processOnMove = function (evt) {
         console.error('Found zombie joystick with ID ' + identifier);
         self.manager.removeIdentifier(identifier);
         return;
+    }
+
+    if (opts.dynamic_page) {
+        var scroll = u.getScroll();
+        pos = nipple.el.getBoundingClientRect();
+        nipple.position = {
+            x: scroll.x + pos.left,
+            y: scroll.y + pos.top
+        };
     }
 
     nipple.identifier = identifier;

--- a/src/collection.js
+++ b/src/collection.js
@@ -34,7 +34,7 @@ function Collection (manager, options) {
         restOpacity: 0.5,
         lockX: false,
         lockY: false,
-        dynamic_page: false
+        dynamicPage: false
     };
 
     self.config(options);
@@ -378,7 +378,7 @@ Collection.prototype.processOnMove = function (evt) {
         return;
     }
 
-    if (opts.dynamic_page) {
+    if (opts.dynamicPage) {
         var scroll = u.getScroll();
         pos = nipple.el.getBoundingClientRect();
         nipple.position = {


### PR DESCRIPTION
This PR fixes #120. 

It adds an option `dynamic_page` that will, if enabled, recompute the position of the nipple on each move event instead of only on resizing the window.

This could have a performance impact, thus an option to enable it has been added.
