### PR TITLE
Add the possibility to set a unit for the size of the stick

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - [Options](#options)
   * [`options.zone` defaults to 'body'](#optionszone-defaults-to-body)
   * [`options.color` defaults to 'white'](#optionscolor-defaults-to-white)
-  * [`options.size` defaults to 100](#optionssize-defaults-to-100)
+  * [`options.size` defaults to {val: 100, unit: "px"}](#optionssize-defaults-to-val-100-unit-px)
   * [`options.threshold` defaults to 0.1](#optionsthreshold-defaults-to-01)
   * [`options.fadeTime` defaults to 250](#optionsfadetime-defaults-to-250)
   * [`options.multitouch` defaults to false](#optionsmultitouch-defaults-to-false)
@@ -127,7 +127,7 @@ You can configure your joystick in different ways :
 var options = {
     zone: Element,                  // active zone
     color: String,
-    size: Integer,
+    size: {val: Integer, unit: String},
     threshold: Float,               // before triggering a directional event
     fadeTime: Integer,              // transition time
     multitouch: Boolean,
@@ -171,8 +171,12 @@ The background color of your joystick's elements.
 
 Can be any valid CSS color.
 
-### `options.size` defaults to 100
-The size in pixel of the outer circle.
+### `options.size` defaults to `{val: 100, unit: "px"}`
+An object that determine the size of the outer circle.
+
+You can pass css unit like : `px`, `vh`, `vmin`
+
+`%` doesn't work if you doesn't set `nipple collection` height and width before
 
 The inner circle is 50% of this size.
 
@@ -279,7 +283,7 @@ Your manager has the following signature :
         mode: String,
         position: Object,
         catchDistance: Number,
-        size: Number,
+        size: {val: Number, unit: String},
         threshold: Number,
         color: String,
         fadeTime: Number,
@@ -371,7 +375,7 @@ Each joystick has the following signature :
     },
     options: {
         color: String,
-        size: Number,
+        size: {val: Number, unit: String},
         threshold: Number,
         fadeTime: Number
     }

--- a/example/dual-joysticks.html
+++ b/example/dual-joysticks.html
@@ -44,7 +44,7 @@
                 mode: 'static',
                 position: { left: '20%', top: '50%' },
                 color: 'green',
-                size: 200
+                size: {val: 200, unit: "px"}
             });
 
             var joystickR = nipplejs.create({
@@ -52,7 +52,7 @@
                 mode: 'static',
                 position: { left: '80%', top: '50%' },
                 color: 'red',
-                size: 200
+                size: {val: 200, unit: "px"}
             });
         </script>
     </body>

--- a/example/lock-axes.html
+++ b/example/lock-axes.html
@@ -44,7 +44,7 @@
                 mode: 'static',
                 position: { left: '20%', top: '50%' },
                 color: 'green',
-                size: 200,
+                size: {val: 200, unit: "px"},
                 lockX: true
             });
 
@@ -53,7 +53,7 @@
                 mode: 'static',
                 position: { left: '80%', top: '50%' },
                 color: 'red',
-                size: 200,
+                size: {val: 200, unit: "px"},
                 lockY: true
             });
         </script>

--- a/src/collection.js
+++ b/src/collection.js
@@ -25,7 +25,10 @@ function Collection (manager, options) {
         mode: 'dynamic',
         position: {top: 0, left: 0},
         catchDistance: 200,
-        size: 100,
+        size: {
+            val: 100,
+            unit: 'px'
+        },
         threshold: 0.1,
         color: 'white',
         fadeTime: 250,
@@ -173,8 +176,8 @@ Collection.prototype.createNipple = function (position, identifier) {
     });
 
     if (!opts.dataOnly) {
-        u.applyPosition(nipple.ui.el, toPutOn);
-        u.applyPosition(nipple.ui.front, nipple.frontPosition);
+        u.applyPosition(nipple.ui.el, toPutOn, opts.size.unit);
+        u.applyPosition(nipple.ui.front, nipple.frontPosition, opts.size.unit);
     }
     self.nipples.push(nipple);
     self.trigger('added ' + nipple.identifier + ':added', nipple);
@@ -389,7 +392,7 @@ Collection.prototype.processOnMove = function (evt) {
 
     nipple.identifier = identifier;
 
-    var size = nipple.options.size / 2;
+    var size = nipple.options.size.val / 2;
     var pos = {
         x: evt.pageX,
         y: evt.pageY
@@ -428,7 +431,7 @@ Collection.prototype.processOnMove = function (evt) {
     };
 
     if (!opts.dataOnly) {
-        u.applyPosition(nipple.ui.front, nipple.frontPosition);
+        u.applyPosition(nipple.ui.front, nipple.frontPosition, opts.size.unit);
     }
 
     // Prepare event's datas.

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -13,7 +13,10 @@ function Nipple (collection, options) {
 
     // Defaults
     this.defaults = {
-        size: 100,
+        size: {
+            val: 100,
+            unit: 'px'
+        },
         threshold: 0.1,
         color: 'white',
         fadeTime: 250,
@@ -110,21 +113,21 @@ Nipple.prototype.stylize = function () {
     styles.back = {
         position: 'absolute',
         display: 'block',
-        width: this.options.size + 'px',
-        height: this.options.size + 'px',
-        marginLeft: -this.options.size / 2 + 'px',
-        marginTop: -this.options.size / 2 + 'px',
+        width: this.options.size.val + this.options.size.unit ,
+        height: this.options.size.val + this.options.size.unit,
+        marginLeft: -this.options.size.val / 2 + this.options.size.unit,
+        marginTop: -this.options.size.val / 2 + this.options.size.unit,
         background: this.options.color,
         'opacity': '.5'
     };
 
     styles.front = {
-        width: this.options.size / 2 + 'px',
-        height: this.options.size / 2 + 'px',
+        width: this.options.size.val / 2 + this.options.size.unit,
+        height: this.options.size.val / 2 + this.options.size.unit,
         position: 'absolute',
         display: 'block',
-        marginLeft: -this.options.size / 4 + 'px',
-        marginTop: -this.options.size / 4 + 'px',
+        marginLeft: -this.options.size.val / 4 + this.options.size.unit,
+        marginTop: -this.options.size.val / 4 + this.options.size.unit,
         background: this.options.color,
         'opacity': '.5'
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,15 +91,15 @@ export const getScroll = () => {
     };
 };
 
-export const applyPosition = (el, pos) => {
+export const applyPosition = (el, pos, unit) => {
     if (pos.top || pos.right || pos.bottom || pos.left) {
         el.style.top = pos.top;
         el.style.right = pos.right;
         el.style.bottom = pos.bottom;
         el.style.left = pos.left;
     } else {
-        el.style.left = pos.x + 'px';
-        el.style.top = pos.y + 'px';
+        el.style.left = pos.x + unit;
+        el.style.top = pos.y + unit;
     }
 };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,12 +18,12 @@ export interface JoystickManagerOptions {
     color?: string;
 
     /**
-     * Defaults to `100`
-     * The size in pixel of the outer circle.
+     * Defaults to { val: `100`, unit: px}
+     * The size of the outer circle.
      *
      * The inner circle is 50% of this size.
      */
-    size?: number;
+    size?: {val: number, unit: string};
 
     /**
      * This is the strength needed to trigger a directional event.


### PR DESCRIPTION
Hi,

I've encountered a problem after using your lib on desktop / mobile.
The problem is the "px" size is not responsive at all so the stick doesn't react the same on all platforms.

I've changed the lib to add a unit / val in the size parameter to allow any unit on the size of the sticks.

The major problem of this update  is, if you release this, you need to update major, cause old code with old size isn't supported. and with the typescript I can't make a retro-compatibility.

Regards,
Arthur Rouet