### PR TITLE
Introduce setPosition Function to Joystick API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
   * [`joystick.add()`](#joystickadd)
   * [`joystick.remove()`](#joystickremove)
   * [`joystick.destroy()`](#joystickdestroy)
-  * [`joystick.setPosition(cb, [{ x, y }])`](#joysticksetpositioncb--x-y-)
+  * [`joystick.setPosition(cb, { x, y })`](#joysticksetpositioncb--x-y-)
   * [`joystick.identifier`](#joystickidentifier)
   * [`joystick.trigger(type [, data])`](#joysticktriggertype--data)
   * [`joystick.position`](#joystickposition)
@@ -419,7 +419,7 @@ Remove the joystick's element from the dom.
 
 Gently remove this nipple from the DOM and unbind all related events.
 
-### `joystick.setPosition(cb, [{ x, y }])`
+### `joystick.setPosition(cb, { x, y })`
 
 Set the joystick to the specified position, where x and y are distances away from the center in pixels. This does not trigger joystick events.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
   * [`joystick.add()`](#joystickadd)
   * [`joystick.remove()`](#joystickremove)
   * [`joystick.destroy()`](#joystickdestroy)
+  * [`joystick.setPosition(cb, [{ x, y }])`](#joysticksetpositioncb--x-y-)
   * [`joystick.identifier`](#joystickidentifier)
   * [`joystick.trigger(type [, data])`](#joysticktriggertype--data)
   * [`joystick.position`](#joystickposition)
@@ -354,6 +355,7 @@ Each joystick has the following signature :
     add: Function,          // inject into dom
     remove: Function,       // remove from dom
     destroy: Function,
+    setPosition: Function,
     identifier: Number,
     trigger: Function,
     position: {             // position of the center
@@ -416,6 +418,10 @@ Remove the joystick's element from the dom.
 ### `joystick.destroy()`
 
 Gently remove this nipple from the DOM and unbind all related events.
+
+### `joystick.setPosition(cb, [{ x, y }])`
+
+Set the joystick to the specified position, where x and y are distances away from the center in pixels. This does not trigger joystick events.
 
 ### `joystick.identifier`
 

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -212,7 +212,7 @@ Nipple.prototype.show = function (cb) {
 };
 
 // Fade out the Nipple instance.
-Nipple.prototype.hide = function (cb =  null) {
+Nipple.prototype.hide = function (cb) {
     var self = this;
 
     if (self.options.dataOnly) {

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -48,6 +48,7 @@ function Nipple (collection, options) {
         add: this.addToDom.bind(this),
         remove: this.removeFromDom.bind(this),
         destroy: this.destroy.bind(this),
+        setPosition:this.setPosition.bind(this),
         resetDirection: this.resetDirection.bind(this),
         computeDirection: this.computeDirection.bind(this),
         trigger: this.trigger.bind(this),
@@ -211,7 +212,7 @@ Nipple.prototype.show = function (cb) {
 };
 
 // Fade out the Nipple instance.
-Nipple.prototype.hide = function (cb) {
+Nipple.prototype.hide = function (cb =  null) {
     var self = this;
 
     if (self.options.dataOnly) {
@@ -237,17 +238,18 @@ Nipple.prototype.hide = function (cb) {
         self.options.fadeTime
     );
     if (self.options.restJoystick) {
-        self.restPosition();
+        self.setPosition(cb, { x: 0, y: 0 });
     }
 
     return self;
 };
 
-Nipple.prototype.restPosition = function (cb) {
+// Set the nipple to the specified position
+Nipple.prototype.setPosition = function (cb, position) {
     var self = this;
     self.frontPosition = {
-        x: 0,
-        y: 0
+        x: position.x,
+        y: position.y
     };
     var animTime = self.options.fadeTime + 'ms';
 


### PR DESCRIPTION
**Description of Change:**
This PR changes `restPosition` to `setPosition` and changes the `hide` function to accommodate for this change. This also updates the README with documentation on how to use this new function. 

`setPosition(cb, { x, y })` takes a callback function (can be undefined) and an object with values `x` and `y`, which is an offset from the centre in pixels. When called, this function will set the nipple to the position specified. 

**Use Case:**
This was created for a specific use case in my application which could be valuable elsewhere. Specifically, we use nipple to control a robot, but we also want to offer the user control via the keyboard in case they find that easier/more natural. To improve the UX, we want to set the nipple to certain positions so that the user can see their key presses are registering (ie, when the user presses the `up` arrow we want to move the nipple upwards as well). 

Another potential use cases could include setting the joystick to a certain position as part of a user tutorial.