### PR TITLE
Fix type declarations for 'shape' and 'mode' for typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -107,7 +107,7 @@ export interface JoystickManagerOptions {
      * each new touch triggers a new direction.
      * cannot be multitouch.
      */
-    mode?: 'dynamic' | 'semi' | 'static';
+    mode?: string;
 
     /**
      * Defaults to `true`
@@ -156,7 +156,7 @@ export interface JoystickManagerOptions {
      *
      * Sets the shape of the joystick
      */
-    shape?: 'circle' | 'square';
+    shape?: string;
 
     /**
      * Defaults to `false`


### PR DESCRIPTION
The type declaration file had issues when handling, well, types on the options 'shape' and 'mode'. Before the element would not be able to render without either ignoring (so they are set to their default' or modifying the type declaration file in your modules directory. 

This small fix should make it easier for the typescript users out there. 