### PR TITLE
feat(improvement): restJoystick now accepts an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ var options = {
     dataOnly: Boolean,              // no dom element whatsoever
     position: Object,               // preset position for 'static' mode
     mode: String,                   // 'dynamic', 'static' or 'semi'
-    restJoystick: Boolean,
+    restJoystick: Boolean|Object,   // Re-center joystick on rest state
     restOpacity: Number,            // opacity when not 'dynamic' and rested
     lockX: Boolean,                 // only move on the X axis
     lockY: Boolean,                 // only move on the Y axis
@@ -244,6 +244,29 @@ Three modes are possible :
 
 ### `options.restJoystick` defaults to true
 Reset the joystick's position when it enters the rest state.
+
+You can pass a boolean value to reset the joystick's position for both the axis.
+```js
+var joystick = nipplejs.create({
+    restJoystick: true,
+    // This is converted to {x: true, y: true}
+
+    // OR
+    restJoystick: false,
+    // This is converted to {x: false, y: false}
+});
+```
+
+Or you can pass an object to specify which axis should be reset.
+```js
+var joystick = nipplejs.create({
+    restJoystick: {x: false},
+    // This is converted to {x: false, y: true}
+
+    // OR
+    restJoystick: {x: false, y: true},
+});
+```
 
 ### `options.restOpacity` defaults to 0.5
 The opacity to apply when the joystick is in a rest position.

--- a/example/reset-joystick.html
+++ b/example/reset-joystick.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>NippleJS</title>
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=0.5, maximum-scale=0.5"
+        />
+        <style>
+            html,
+            body {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            #left {
+                position: absolute;
+                left: 0;
+                top: 0;
+                height: 100%;
+                width: 50%;
+                background: rgba(0, 255, 0, 0.1);
+            }
+
+            #right {
+                position: absolute;
+                right: 0;
+                top: 0;
+                height: 100%;
+                width: 50%;
+                background: rgba(0, 0, 255, 0.1);
+            }
+        </style>
+    </head>
+    <body>
+        <div id="left"></div>
+        <div id="right"></div>
+        <script src="/dist/nipplejs.js"></script>
+        <script>
+            var joystickL = nipplejs.create({
+                zone: document.getElementById("left"),
+                mode: "static",
+                position: { left: "30%", top: "50%" },
+                color: "green",
+                size: 200,
+                restJoystick: {y: false}
+            });
+
+            var joystickR = nipplejs.create({
+                zone: document.getElementById("right"),
+                mode: "static",
+                position: { left: "70%", top: "50%" },
+                color: "red",
+                size: 200,
+                restJoystick: false
+            });
+        </script>
+    </body>
+</html>

--- a/example/reset-joystick.html
+++ b/example/reset-joystick.html
@@ -49,7 +49,7 @@
                 position: { left: "30%", top: "50%" },
                 color: "green",
                 size: 200,
-                restJoystick: {y: false}
+                restJoystick: { y: false }
             });
 
             var joystickR = nipplejs.create({

--- a/src/collection.js
+++ b/src/collection.js
@@ -50,19 +50,6 @@ function Collection (manager, options) {
         self.options.maxNumberOfNipples = 1;
     }
 
-    // Convert this.option.restJoystick 
-    // to `RestJoystickOption` type.
-    const restJoystick = this.options.restJoystick;
-
-    if(typeof restJoystick === 'boolean'){
-        this.options.restJoystick = {
-            x: restJoystick,
-            y: restJoystick,
-        };
-    }else if(typeof restJoystick === 'object'){
-        this.options.restJoystick = u.safeExtend({x:true,y:true},restJoystick);
-    }
-
     self.updateBox();
     self.prepareNipples();
     self.bindings();

--- a/src/collection.js
+++ b/src/collection.js
@@ -50,6 +50,19 @@ function Collection (manager, options) {
         self.options.maxNumberOfNipples = 1;
     }
 
+    // Convert this.option.restJoystick 
+    // to `RestJoystickOption` type.
+    const restJoystick = this.options.restJoystick;
+
+    if(typeof restJoystick === 'boolean'){
+        this.options.restJoystick = {
+            x: restJoystick,
+            y: restJoystick,
+        };
+    }else if(typeof restJoystick === 'object'){
+        this.options.restJoystick = u.safeExtend({x:true,y:true},restJoystick);
+    }
+
     self.updateBox();
     self.prepareNipples();
     self.bindings();

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -34,6 +34,19 @@ function Nipple (collection, options) {
         this.options.restOpacity = 0;
     }
 
+    // Convert this.option.restJoystick 
+    // to `RestJoystickOption` type.
+    const restJoystick = this.options.restJoystick;
+
+    if(typeof restJoystick === 'boolean'){
+        this.options.restJoystick = {
+            x: restJoystick,
+            y: restJoystick,
+        };
+    }else if(typeof restJoystick === 'object'){
+        this.options.restJoystick = u.safeExtend({x:true,y:true},restJoystick);
+    }
+
     this.id = Nipple.id;
     Nipple.id += 1;
     this.buildEl()
@@ -240,9 +253,12 @@ Nipple.prototype.hide = function (cb) {
         },
         self.options.fadeTime
     );
-    if (self.options.restJoystick) {
-        self.setPosition(cb, { x: 0, y: 0 });
-    }
+
+
+    self.setPosition(cb, { 
+        x: self.options.restJoystick.x ?0 :self.instance.frontPosition.x, 
+        y: self.options.restJoystick.y ?0 :self.instance.frontPosition.y 
+    });
 
     return self;
 };

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -34,19 +34,6 @@ function Nipple (collection, options) {
         this.options.restOpacity = 0;
     }
 
-    // Convert this.option.restJoystick 
-    // to `RestJoystickOption` type.
-    const restJoystick = this.options.restJoystick;
-
-    if(typeof restJoystick === 'boolean'){
-        this.options.restJoystick = {
-            x: restJoystick,
-            y: restJoystick,
-        };
-    }else if(typeof restJoystick === 'object'){
-        this.options.restJoystick = u.safeExtend({x:true,y:true},restJoystick);
-    }
-
     this.id = Nipple.id;
     Nipple.id += 1;
     this.buildEl()
@@ -254,11 +241,15 @@ Nipple.prototype.hide = function (cb) {
         self.options.fadeTime
     );
 
+    if (self.options.restJoystick) {
+        const rest = self.options.restJoystick;
+        const newPosition = {};
 
-    self.setPosition(cb, { 
-        x: self.options.restJoystick.x ?0 :self.instance.frontPosition.x, 
-        y: self.options.restJoystick.y ?0 :self.instance.frontPosition.y 
-    });
+        newPosition.x = rest === true || rest.x !== false ? 0 : self.instance.frontPosition.x;
+        newPosition.y = rest === true || rest.y !== false ? 0 : self.instance.frontPosition.y;
+
+        self.setPosition(cb, newPosition);
+    }
 
     return self;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -114,7 +114,7 @@ export interface JoystickManagerOptions {
      *
      * Reset the joystick’s position when it enters the rest state.
      */
-    restJoystick?: boolean;
+    restJoystick?: boolean | RestJoystickOption;
 
     /**
      * Defaults to `0.5`
@@ -164,6 +164,17 @@ export interface JoystickManagerOptions {
      * Make the joystick follow the cursor beyond its limits.
      */
     follow?: boolean;
+}
+
+export interface RestJoystickOption {
+    /**
+     * Defaults to `true`
+     */
+    x?: boolean,
+    /**
+     * Defaults to `true`
+     */
+    y?: boolean,
 }
 
 export interface Position {


### PR DESCRIPTION
Currently the `restJoystick` option only accepts `boolean` values. This means that I can't specify which axis should be re-centered on rest state. For example, in my use case I only want the Y-axis to be reset on rest state while the X-axis should remain in the same position.

This improvement will add this capability to the library. This is how we'll be able to use `restJoystick` option:
```js
var joystick = nipple.create({
    restJoystick: true,
    // This is converted to {x: true, y: true}

    // OR
    restJoystick: false,
    // This is converted to {x: false, y: false}

    // OR
    restJoystick: {x: false},
    // This is converted to {x: false, y: true}

    // OR
    restJoystick: {x: false, y: true},
});
```

Although a small improvement, it'll be useful of many of us.