### PR TITLE
feat: on multiple events accept array

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ manager.on('event#1 event#2', function (evt, data) {
 Note that you can listen to multiple events at once by separating
 them either with a space or a comma (or both, I don't care).
 
+You can also separate events in an array.
+```javascript
+manager.on(['event#1', 'event#2'], function (evt, data) {
+    // Do something.
+});
+```
+
 #### `manager.off([type, handler])`
 
 To remove an event handler :

--- a/example/codepen-demo.html
+++ b/example/codepen-demo.html
@@ -239,7 +239,7 @@
             createNipple('dynamic');
 
             function bindNipple () {
-                joystick.on('start end', function (evt, data) {
+                joystick.on(['start', 'end'], function (evt, data) {
                     dump(evt.type);
                     debug(data);
                 }).on('move', function (evt, data) {

--- a/src/super.js
+++ b/src/super.js
@@ -47,7 +47,7 @@ function Super () {}
 // Basic event system.
 Super.prototype.on = function (arg, cb) {
     var self = this;
-    var types = arg.split(/[ ,]+/g);
+    var types = Array.isArray(arg) ? arg: arg.split(/[ ,]+/g);
     var type;
     self._handlers_ = self._handlers_ || {};
 


### PR DESCRIPTION
Hi,

The type definition for `Joystick.on` and `JoystickManager.on` accepts arrays of events or only one event as a string. However this is not the case for the real `on` function which accepts only strings. So it's not possible to use multiple events correctly in TypeScript. This PR adds support for arrays of events.