### PR TITLE
 fix(zone): handle offset when parent is flex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.vscode

--- a/src/collection.js
+++ b/src/collection.js
@@ -49,6 +49,10 @@ function Collection (manager, options) {
     if (!self.options.multitouch) {
         self.options.maxNumberOfNipples = 1;
     }
+    const computedStyle = getComputedStyle(self.options.zone.parentElement);
+    if (computedStyle && computedStyle.display === 'flex') {
+        self.parentIsFlex = true;
+    }
 
     self.updateBox();
     self.prepareNipples();
@@ -121,13 +125,15 @@ Collection.prototype.createNipple = function (position, identifier) {
     var scroll = self.manager.scroll;
     var toPutOn = {};
     var opts = self.options;
+    var offset = {
+        x: self.parentIsFlex ? scroll.x : (scroll.x + self.box.left),
+        y: self.parentIsFlex ? scroll.y : (scroll.y + self.box.top)
+    };
 
     if (position.x && position.y) {
         toPutOn = {
-            x: position.x -
-                (scroll.x + self.box.left),
-            y: position.y -
-                (scroll.y + self.box.top)
+            x: position.x - offset.x,
+            y: position.y - offset.y
         };
     } else if (
         position.top ||

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -331,6 +331,7 @@ export interface Collection {
     manager: JoystickManager;
     id: number;
     defaults: JoystickManagerOptions;
+    parentIsFlex: boolean;
 }
 
 export interface Joystick {


### PR DESCRIPTION
Fixes https://github.com/yoannmoinet/nipplejs/issues/181

When the parent is `display: flex` somehow the offset is wrong.
I suspect that the context of the `getBoundingBox` is inexistant in `flex` mode.

The solution would be to remove that offset when we detect that the parent is `display: flex`.