### PR TITLE
fix: use transform translate for nipple front

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -461,7 +461,7 @@ Collection.prototype.processOnMove = function (evt) {
     };
 
     if (!opts.dataOnly) {
-        u.applyPosition(nipple.ui.front, nipple.frontPosition);
+        nipple.ui.front.style.transform = 'translate(' + xPosition + 'px,' + yPosition + 'px)';
     }
 
     // Prepare event's datas.

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -128,7 +128,8 @@ Nipple.prototype.stylize = function () {
         marginLeft: -this.options.size / 4 + 'px',
         marginTop: -this.options.size / 4 + 'px',
         background: this.options.color,
-        'opacity': '.5'
+        'opacity': '.5',
+        transform: undefined,
     };
 
     u.extend(styles.el, transitStyle);
@@ -265,12 +266,11 @@ Nipple.prototype.setPosition = function (cb, position) {
 
     var transitStyle = {};
     transitStyle.front = u.getTransitionStyle('transition',
-        ['top', 'left'], animTime);
+        ['transform'], animTime);
 
     var styles = {front: {}};
     styles.front = {
-        left: self.frontPosition.x + 'px',
-        top: self.frontPosition.y + 'px'
+        transform: 'translate(' + self.frontPosition.x + 'px,' + self.frontPosition.y + 'px)',
     };
 
     self.applyStyles(transitStyle);

--- a/src/nipple.js
+++ b/src/nipple.js
@@ -129,7 +129,7 @@ Nipple.prototype.stylize = function () {
         marginTop: -this.options.size / 4 + 'px',
         background: this.options.color,
         'opacity': '.5',
-        transform: undefined,
+        transform: 'translate(0px, 0px)'
     };
 
     u.extend(styles.el, transitStyle);
@@ -270,7 +270,7 @@ Nipple.prototype.setPosition = function (cb, position) {
 
     var styles = {front: {}};
     styles.front = {
-        transform: 'translate(' + self.frontPosition.x + 'px,' + self.frontPosition.y + 'px)',
+        transform: 'translate(' + self.frontPosition.x + 'px,' + self.frontPosition.y + 'px)'
     };
 
     self.applyStyles(transitStyle);


### PR DESCRIPTION
As discussed in https://github.com/yoannmoinet/nipplejs/issues/168, this uses transform: translate instead of setting top/left on the nipple front.

Two notes that might be worth their own issue:

The npm prepare script runs on npm install, and setting NODE_ENV fails on windows. I'd personally prefer cross-env for something like this.
Also, 6 of the tests fail without any of my changes? 6 still fail with them.