### PR TITLE
fix: missing type for `setPosition`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -349,6 +349,7 @@ export interface Joystick {
     add(): void;
     remove(): void;
     destroy(): void;
+    setPosition(cb: (joystick: Joystick) => void, position: Position): void;
     identifier: number;
     trigger(
         type: JoystickEventTypes | JoystickEventTypes[],


### PR DESCRIPTION
This type was missing from the type definitions.