### PR TITLE
fix(manager): add `ids` & `id` to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -320,6 +320,8 @@ export class JoystickManager {
     ): void;
     get(identifier: number): Joystick;
     destroy(): void;
+    ids: number[];
+    id: number;
 }
 
 export interface Collection {


### PR DESCRIPTION
### What

- add `ids` & `id` to types

### Why

- they are missing, which makes accessing them inconvenient in TypeScript

### Visuals

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/12933406/221498872-c86361e8-fdaf-4f33-904a-3e5db247a71d.png)|![image](https://user-images.githubusercontent.com/12933406/221499146-7c9a7049-1dc2-4168-83d1-faeaa253150c.png)|
