### PR TITLE
refactor(nipple): add strict types for JoystickOutputData direction

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -182,16 +182,18 @@ export interface Position {
     y: number;
 }
 
+export interface Direction {
+    angle: 'up' | 'down' | 'right' | 'left';
+    x: 'left' | 'right';
+    y: 'up' | 'down';
+}
+
 export interface JoystickOutputData {
     angle: {
         degree: number;
         radian: number;
     };
-    direction: {
-        angle: string;
-        x: string;
-        y: string;
-    };
+    direction: Direction;
     vector: {
         x: number;
         y: number;


### PR DESCRIPTION
### What
Add string literal types for `JoystickOutputData` object's `direction` property

### Why
In the source, those are the only values ever assigned to them and would help with auto-complete and type-safety.