### PR TITLE
fix: non browser environment compatibility which breaks SSR compilation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
 import Manager from './manager';
 
-const factory = new Manager();
+let factory;
+if(typeof window !== 'undefined'){
+    factory = new Manager();
+}
 export default {
     create: function (options) {
+        if(!factory) {
+            throw new Error('Nipplejs library can only run in a browser. \'window\' is not defined.');
+        }
         return factory.create(options);
     },
     factory: factory

--- a/src/super.js
+++ b/src/super.js
@@ -4,9 +4,6 @@
 import * as u from './utils';
 
 // Constants
-var isTouch = !!('ontouchstart' in window);
-var isPointer = window.PointerEvent ? true : false;
-var isMSPointer = window.MSPointerEvent ? true : false;
 var events = {
     touch: {
         start: 'touchstart',
@@ -29,18 +26,30 @@ var events = {
         end: 'MSPointerUp'
     }
 };
-var toBind;
-var secondBind = {};
-if (isPointer) {
-    toBind = events.pointer;
-} else if (isMSPointer) {
-    toBind = events.MSPointer;
-} else if (isTouch) {
-    toBind = events.touch;
-    secondBind = events.mouse;
-} else {
-    toBind = events.mouse;
+
+function getBindings() {
+    var toBind;
+    var secondBind = {};
+    var isTouch = !!('ontouchstart' in window);
+    var isPointer = window.PointerEvent ? true : false;
+    var isMSPointer = window.MSPointerEvent ? true : false;
+
+    if (isPointer) {
+        toBind = events.pointer;
+    } else if (isMSPointer) {
+        toBind = events.MSPointer;
+    } else if (isTouch) {
+        toBind = events.touch;
+        secondBind = events.mouse;
+    } else {
+        toBind = events.mouse;
+    }
+    return {
+        toBind,
+        secondBind
+    };
 }
+
 
 function Super () {}
 
@@ -117,6 +126,7 @@ Super.prototype.bindEvt = function (el, type) {
         }
     };
 
+    var { toBind, secondBind } = getBindings();
     u.bindEvt(el, toBind[type], self._domHandlers_[type]);
 
     if (secondBind[type]) {
@@ -132,6 +142,7 @@ Super.prototype.unbindEvt = function (el, type) {
     var self = this;
     self._domHandlers_ = self._domHandlers_ || {};
 
+    var { toBind, secondBind } = getBindings();
     u.unbindEvt(el, toBind[type], self._domHandlers_[type]);
 
     if (secondBind[type]) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = {
         library: NAME,
         libraryExport: 'default',
         libraryTarget: 'umd',
-        umdNamedDefine: true
+        umdNamedDefine: true,
+        globalObject: 'typeof self !== \'undefined\' ? self : this',
     },
     module: {
         rules: [


### PR DESCRIPTION
Hello @yoannmoinet ,

To make the story as short as possible:
- [super.js](https://github.com/yoannmoinet/nipplejs/commit/3b777ca140aed1bad8be069b04be7dffdfb42cd6#diff-869a58fca30e80602a48ea799318d673386b161ccb86a5eae3e7b84482bd5141L7-L38) has global access to the global `window` object which only exists in a web browser environment.
- I use nextjs, which uses SSR component (server side rendered component). 
- SSR component doesn't need nipplejs, but it imports client side components which use nipplejs.
- That means SSR compilation imports the nipplejs module no matter it really uses it server side or not.
- So the SSR compilation fails because the `window` object in `super.js` is accessed at the nipplejs module import, and also because on top of that the nipplejs library itself is built as umd but without defining `globalObject` in webpack config for the [compatibility on non browser environments](https://webpack.js.org/configuration/output/#outputglobalobject).

For the record, the error is:
> ReferenceError: window is not defined

So this PR has 2 commits:
- [one](https://github.com/yoannmoinet/nipplejs/pull/226/commits/6d5656638ea33ec508a40e0267fcf1233b6daa11) to prevent accessing `window` object globally during the `super.js` module import
- [another](https://github.com/yoannmoinet/nipplejs/pull/226/commits/cc3f1c7e078a008ae7c2d809502210a141296b97) to define `globalObject` in non browser environment and throw an error if nipplejs `Manager.create` is actually called from a non browser environment.

If you could accept that and release a nipplejs version toward it, I'd be really grateful 🙏

> N.B: I first tried to mock the nipplejs module resolution during SSR compilation using the webpack config of nextjs config. But I did not find a config that fix the issue. Apparently because the nodejs resolve the modules earlier but I'm not sure about that...