### PR TITLE
Fix static joystick

### DIFF
--- a/packages/nipplejs/src/Collection.test.ts
+++ b/packages/nipplejs/src/Collection.test.ts
@@ -25,6 +25,23 @@ const createMockZone = (): HTMLElement => {
     return zone;
 };
 
+// Helper: get the first (and usually only) joystick in a collection.
+// Centralises the non-null assertion so individual tests stay clean.
+const getFirstJoystick = (collection: Collection): Joystick =>
+    collection.all.values().next().value!;
+
+// Helper: get the first joystick and mark it active under a given identifier.
+// Skips the processOnStart machinery for tests that exercise a later event.
+const getFirstJoystickAndSetActive = (
+    collection: Collection,
+    identifier: Identifier = 1 as Identifier,
+): Joystick => {
+    const joystick = getFirstJoystick(collection);
+    joystick.identifier = identifier;
+    collection.actives.set(identifier, joystick);
+    return joystick;
+};
+
 describe('Collection', () => {
     let mockFactory: jest.Mocked<Factory>;
     let mockZone: HTMLElement;
@@ -184,7 +201,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
+            const joystick = getFirstJoystick(collection);
             const found = collection.getJoystickByUid(joystick.uid);
 
             expect(found).toBe(joystick);
@@ -198,7 +215,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
+            const joystick = getFirstJoystick(collection);
             const found = collection.getJoystickByUid(undefined);
 
             expect(found).toBe(joystick);
@@ -222,7 +239,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
+            const joystick = getFirstJoystick(collection);
 
             expect(collection.idles.has(joystick.uid)).toBe(true);
         });
@@ -235,7 +252,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
+            const joystick = getFirstJoystick(collection);
             collection.idles.delete(joystick.uid);
 
             expect(collection.idles.has(joystick.uid)).toBe(false);
@@ -356,8 +373,10 @@ describe('Collection', () => {
 
             collection.processOnEnd(evt1 as any);
 
-            // Wait for fadeTime animation to move joystick back to idle
-            jest.advanceTimersByTime(300);
+            // Mid-fade: joystick is in `resting` (identifier-keyed) AND in
+            // `idles` (uid-keyed) so a new touch can reuse it immediately.
+            expect(collection.resting.size).toBe(1);
+            expect(collection.idles.size).toBe(1);
 
             // Create new event within catch distance
             const evt2 = {
@@ -374,6 +393,8 @@ describe('Collection', () => {
             // Should reuse the same joystick
             expect(secondJoystick).toBe(firstJoystick);
             expect(collection.all.size).toBe(1);
+            // Reusing clears the stale resting entry from the prior cycle.
+            expect(collection.resting.size).toBe(0);
 
             jest.useRealTimers();
         });
@@ -400,10 +421,7 @@ describe('Collection', () => {
 
             collection.processOnEnd(evt1 as any);
 
-            // Wait for fadeTime animation to move joystick back to idle
-            jest.advanceTimersByTime(300);
-
-            // Create new event beyond catch distance
+            // Create new event beyond catch distance (joystick still mid-fade).
             const evt2 = {
                 identifier: 2 as Identifier,
                 position: { x: 200, y: 100 },
@@ -463,8 +481,10 @@ describe('Collection', () => {
 
             collection.processOnEnd(evt1 as any);
 
-            // Wait for fadeTime animation to move joystick back to idle
-            jest.advanceTimersByTime(300);
+            // Mid-fade: joystick is in `resting` AND `idles`, so a second
+            // touch reuses it without waiting for `hidden` to fire.
+            expect(collection.resting.size).toBe(1);
+            expect(collection.idles.size).toBe(1);
 
             collection.processOnStart(evt2 as any);
             const secondJoystick = collection.actives.get(evt2.identifier);
@@ -472,21 +492,20 @@ describe('Collection', () => {
             // Should reuse the same joystick
             expect(secondJoystick).toBe(firstJoystick);
             expect(collection.all.size).toBe(1);
+            // Reusing clears the stale resting entry from the prior cycle.
+            expect(collection.resting.size).toBe(0);
 
             jest.useRealTimers();
         });
 
-        it('static mode: reuses singleton when a new touch starts while joystick is still resting (before hidden)', () => {
-            jest.useFakeTimers();
-
+        it('static mode + dataOnly: reuses joystick on subsequent taps (hidden never fires)', () => {
             const collection = new Collection(mockFactory, {
                 zone: mockZone,
                 mode: MODES.static,
+                dataOnly: true,
             });
 
             collection.init();
-
-            const singletonJoystick = collection.all.values().next().value!;
 
             const evt1 = {
                 identifier: 1 as Identifier,
@@ -503,17 +522,18 @@ describe('Collection', () => {
             };
 
             collection.processOnStart(evt1 as any);
+            const firstJoystick = collection.actives.get(evt1.identifier);
+
             collection.processOnEnd(evt1 as any);
 
-            expect(collection.idles.size).toBe(0);
-            expect(collection.resting.size).toBe(1);
+            // dataOnly short-circuits the fade machinery — `hidden` never
+            // fires, but `idles` is populated on `end` so reuse still works.
+            expect(collection.idles.size).toBe(1);
 
             collection.processOnStart(evt2 as any);
 
+            expect(collection.actives.get(evt2.identifier)).toBe(firstJoystick);
             expect(collection.all.size).toBe(1);
-            expect(collection.actives.get(evt2.identifier)).toBe(singletonJoystick);
-
-            jest.useRealTimers();
         });
     });
 
@@ -545,9 +565,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            const joystick = getFirstJoystickAndSetActive(collection);
 
             const evt = {
                 identifier: 1 as Identifier,
@@ -572,9 +590,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            const joystick = getFirstJoystickAndSetActive(collection);
 
             const triggerSpy = jest.spyOn(joystick, 'trigger');
 
@@ -598,9 +614,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            getFirstJoystickAndSetActive(collection);
 
             const evt = {
                 identifier: 1 as Identifier,
@@ -625,9 +639,7 @@ describe('Collection', () => {
 
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            const joystick = getFirstJoystickAndSetActive(collection);
 
             const triggerSpy = jest.spyOn(joystick, 'trigger');
 
@@ -694,9 +706,7 @@ describe('Collection', () => {
             });
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            const joystick = getFirstJoystickAndSetActive(collection);
 
             const triggerSpy = jest.spyOn(joystick, 'computeDirectionAndTriggerEvents');
 
@@ -720,9 +730,7 @@ describe('Collection', () => {
             });
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            const joystick = getFirstJoystickAndSetActive(collection);
 
             const triggerSpy = jest.spyOn(joystick, 'computeDirectionAndTriggerEvents');
 
@@ -748,9 +756,7 @@ describe('Collection', () => {
             });
             collection.init();
 
-            const joystick = collection.all.values().next().value;
-            joystick.identifier = 1 as Identifier;
-            collection.actives.set(1 as Identifier, joystick);
+            const joystick = getFirstJoystickAndSetActive(collection);
 
             const triggerSpy = jest.spyOn(joystick, 'computeDirectionAndTriggerEvents');
 
@@ -838,7 +844,7 @@ describe('Collection', () => {
             });
             collection.init();
 
-            const joystick = collection.all.values().next().value;
+            const joystick = getFirstJoystick(collection);
 
             collection.reposition();
 

--- a/packages/nipplejs/src/Collection.test.ts
+++ b/packages/nipplejs/src/Collection.test.ts
@@ -475,6 +475,46 @@ describe('Collection', () => {
 
             jest.useRealTimers();
         });
+
+        it('static mode: reuses singleton when a new touch starts while joystick is still resting (before hidden)', () => {
+            jest.useFakeTimers();
+
+            const collection = new Collection(mockFactory, {
+                zone: mockZone,
+                mode: MODES.static,
+            });
+
+            collection.init();
+
+            const singletonJoystick = collection.all.values().next().value!;
+
+            const evt1 = {
+                identifier: 1 as Identifier,
+                position: { x: 100, y: 100 },
+                pressure: 1,
+                raw: {} as any,
+            };
+
+            const evt2 = {
+                identifier: 2 as Identifier,
+                position: { x: 150, y: 150 },
+                pressure: 1,
+                raw: {} as any,
+            };
+
+            collection.processOnStart(evt1 as any);
+            collection.processOnEnd(evt1 as any);
+
+            expect(collection.idles.size).toBe(0);
+            expect(collection.resting.size).toBe(1);
+
+            collection.processOnStart(evt2 as any);
+
+            expect(collection.all.size).toBe(1);
+            expect(collection.actives.get(evt2.identifier)).toBe(singletonJoystick);
+
+            jest.useRealTimers();
+        });
     });
 
     describe('Event Processing', () => {

--- a/packages/nipplejs/src/Collection.ts
+++ b/packages/nipplejs/src/Collection.ts
@@ -192,20 +192,32 @@ export class Collection extends Super {
             this.deleteIdentifierFromLists(evt.data.identifier);
         });
 
-        // When a Joystick gets hidden, we move it from active to resting.
+        // When a Joystick is released, mark it reusable immediately.
+        // `resting` keeps the identifier-keyed index for same-pointer recovery
+        // in processOnStart; `idles` is the uid-keyed pool getOrCreate uses.
         joystick.on('end', (evt) => {
             if (u.isNumber(evt.data.identifier)) {
                 this.actives.delete(evt.data.identifier);
                 this.resting.set(evt.data.identifier, joystick);
             }
+            this.idles.add(evt.data.uid);
         });
 
-        // When a Joystick gets hidden, we move it from resting to idle.
+        // When a Joystick is reused mid-fade, start() clears the removeTimeout
+        // so `hidden` never fires for the prior identifier. Drop the stale
+        // resting entry here, where `joystick.identifier` still holds it.
+        joystick.on('start', (evt) => {
+            if (u.isNumber(evt.data.identifier)) {
+                this.resting.delete(evt.data.identifier);
+            }
+        });
+
+        // After the fade-out completes, drop the resting index entry.
+        // `idles` was already populated on `end`.
         joystick.on('hidden', (evt) => {
             if (u.isNumber(evt.data.identifier)) {
                 this.resting.delete(evt.data.identifier);
             }
-            this.idles.add(evt.data.uid);
         });
 
         // Other events that will get bubbled up.
@@ -263,28 +275,6 @@ export class Collection extends Super {
         this.resting.delete(identifier);
     }
 
-    /**
-     * In static mode there must only ever be one joystick per collection. When the user
-     * releases, the instance can sit in `resting` (between `end` and `hidden`) with nothing
-     * in `idles` yet; a new pointer id must still resolve to that same instance from `all`.
-     */
-    private getSingletonStaticJoystickIfPresent(): Joystick | undefined {
-        let singletonStaticJoystick: Joystick | undefined;
-        if (this.options.mode === MODES.static && this.all.size > 0) {
-            const uidsOrdered: Uid[] = [...this.all.keys()].sort(
-                (a: Uid, b: Uid): number => Number(a) - Number(b),
-            );
-            const firstJoystickUid: Uid | undefined = uidsOrdered[0];
-            if (u.isNumber(firstJoystickUid)) {
-                const joystickFromMap: Joystick | undefined = this.all.get(firstJoystickUid);
-                if (typeof joystickFromMap !== 'undefined') {
-                    singletonStaticJoystick = joystickFromMap;
-                }
-            }
-        }
-        return singletonStaticJoystick;
-    }
-
     private getOrCreate(position: Coordinates): Joystick {
         // In semi and static modes, we recycle the idle joystick.
         if (this.options.mode === MODES.semi || this.options.mode === MODES.static) {
@@ -299,12 +289,6 @@ export class Collection extends Super {
                 } else {
                     return joystick;
                 }
-            }
-
-            const singletonStaticJoystick: Joystick | undefined =
-                this.getSingletonStaticJoystickIfPresent();
-            if (typeof singletonStaticJoystick !== 'undefined') {
-                return singletonStaticJoystick;
             }
 
             // In semi mode, we may not have an idle joystick.
@@ -323,11 +307,6 @@ export class Collection extends Super {
     }
 
     private createJoystick(position: AnyPosition): Joystick {
-        const existingStaticJoystick: Joystick | undefined =
-            this.getSingletonStaticJoystickIfPresent();
-        if (typeof existingStaticJoystick !== 'undefined') {
-            return existingStaticJoystick;
-        }
         const scroll = this.factory.scroll;
         // Offset converts page-absolute coordinates to zone-relative.
         // In flex containers, absolute children are positioned relative to the

--- a/packages/nipplejs/src/Collection.ts
+++ b/packages/nipplejs/src/Collection.ts
@@ -263,6 +263,28 @@ export class Collection extends Super {
         this.resting.delete(identifier);
     }
 
+    /**
+     * In static mode there must only ever be one joystick per collection. When the user
+     * releases, the instance can sit in `resting` (between `end` and `hidden`) with nothing
+     * in `idles` yet; a new pointer id must still resolve to that same instance from `all`.
+     */
+    private getSingletonStaticJoystickIfPresent(): Joystick | undefined {
+        let singletonStaticJoystick: Joystick | undefined;
+        if (this.options.mode === MODES.static && this.all.size > 0) {
+            const uidsOrdered: Uid[] = [...this.all.keys()].sort(
+                (a: Uid, b: Uid): number => Number(a) - Number(b),
+            );
+            const firstJoystickUid: Uid | undefined = uidsOrdered[0];
+            if (u.isNumber(firstJoystickUid)) {
+                const joystickFromMap: Joystick | undefined = this.all.get(firstJoystickUid);
+                if (typeof joystickFromMap !== 'undefined') {
+                    singletonStaticJoystick = joystickFromMap;
+                }
+            }
+        }
+        return singletonStaticJoystick;
+    }
+
     private getOrCreate(position: Coordinates): Joystick {
         // In semi and static modes, we recycle the idle joystick.
         if (this.options.mode === MODES.semi || this.options.mode === MODES.static) {
@@ -277,6 +299,12 @@ export class Collection extends Super {
                 } else {
                     return joystick;
                 }
+            }
+
+            const singletonStaticJoystick: Joystick | undefined =
+                this.getSingletonStaticJoystickIfPresent();
+            if (typeof singletonStaticJoystick !== 'undefined') {
+                return singletonStaticJoystick;
             }
 
             // In semi mode, we may not have an idle joystick.
@@ -295,6 +323,11 @@ export class Collection extends Super {
     }
 
     private createJoystick(position: AnyPosition): Joystick {
+        const existingStaticJoystick: Joystick | undefined =
+            this.getSingletonStaticJoystickIfPresent();
+        if (typeof existingStaticJoystick !== 'undefined') {
+            return existingStaticJoystick;
+        }
         const scroll = this.factory.scroll;
         // Offset converts page-absolute coordinates to zone-relative.
         // In flex containers, absolute children are positioned relative to the


### PR DESCRIPTION
Joysticks in static mode do not function properly. You can easily reproduce this with the "Neon Snake" demo on the site. Everything is fine when using a mouse but if you use chrome dev tools to use touch instead (or just test on a mobile phone) you'll see that if you tap on the joystick over and over it will start spawning more than 1.