### PR TITLE
Fix/type overload and dom containment

### DIFF
--- a/packages/nipplejs/src/Joystick.test.ts
+++ b/packages/nipplejs/src/Joystick.test.ts
@@ -652,6 +652,92 @@ describe('Joystick', () => {
         });
     });
 
+    describe('addToDom() / removeFromDom()', () => {
+        it('addToDom() does not add the element twice when already in the zone', () => {
+            const zone = document.createElement('div');
+            document.body.appendChild(zone);
+
+            const collection = createMockCollection();
+            collection.options.zone = zone;
+
+            const joystick = new Joystick(collection, {
+                position: { x: 100, y: 100 },
+                frontPosition: { x: 0, y: 0 },
+                dataOnly: false,
+                zone,
+            });
+
+            joystick.init();
+
+            joystick.addToDom();
+            const childCountAfterFirst = zone.childElementCount;
+
+            joystick.addToDom();
+            expect(zone.childElementCount).toBe(childCountAfterFirst);
+
+            document.body.removeChild(zone);
+        });
+
+        it('addToDom() appends to zone even when zone is not inside document.body', () => {
+            const detachedZone = document.createElement('div');
+
+            const collection = createMockCollection();
+            collection.options.zone = detachedZone;
+
+            const joystick = new Joystick(collection, {
+                position: { x: 100, y: 100 },
+                frontPosition: { x: 0, y: 0 },
+                dataOnly: false,
+                zone: detachedZone,
+            });
+
+            joystick.init();
+
+            joystick.addToDom();
+            expect(detachedZone.contains(joystick.ui.el)).toBe(true);
+        });
+
+        it('removeFromDom() removes the element from the zone', () => {
+            const zone = document.createElement('div');
+            document.body.appendChild(zone);
+
+            const collection = createMockCollection();
+            collection.options.zone = zone;
+
+            const joystick = new Joystick(collection, {
+                position: { x: 100, y: 100 },
+                frontPosition: { x: 0, y: 0 },
+                dataOnly: false,
+                zone,
+            });
+
+            joystick.init();
+
+            joystick.addToDom();
+            expect(zone.contains(joystick.ui.el)).toBe(true);
+
+            joystick.removeFromDom();
+            expect(zone.contains(joystick.ui.el)).toBe(false);
+
+            document.body.removeChild(zone);
+        });
+    });
+
+    describe('buildEl()', () => {
+        it('sets touch-action and user-select to none on the joystick element', () => {
+            const joystick = new Joystick(mockCollection, {
+                position: { x: 100, y: 100 },
+                frontPosition: { x: 0, y: 0 },
+                dataOnly: false,
+            });
+
+            joystick.init();
+
+            expect(joystick.ui.el.style.touchAction).toBe('none');
+            expect(joystick.ui.el.style.userSelect).toBe('none');
+        });
+    });
+
     describe('Move Event Continuity', () => {
         it('fires move event even when direction has not changed', () => {
             const joystick = new Joystick(mockCollection, {

--- a/packages/nipplejs/src/Joystick.ts
+++ b/packages/nipplejs/src/Joystick.ts
@@ -137,6 +137,8 @@ export class Joystick extends Super {
             opacity: this.options.restOpacity.toString(),
             display: 'block',
             zIndex: '999',
+            touchAction: 'none',
+            userSelect: 'none',
             ...transitStyle,
         });
 
@@ -196,7 +198,7 @@ export class Joystick extends Super {
     // Inject the Joystick instance into DOM.
     addToDom(): void {
         // We're not adding it if we're dataOnly or already in dom.
-        if (this.options.dataOnly || document.body.contains(this.ui.el)) {
+        if (this.options.dataOnly || this.options.zone.contains(this.ui.el)) {
             return;
         }
         this.options.zone.appendChild(this.ui.el);
@@ -204,7 +206,7 @@ export class Joystick extends Super {
 
     // Remove the Joystick instance from DOM.
     removeFromDom(): void {
-        if (this.options.dataOnly || !document.body.contains(this.ui.el)) {
+        if (this.options.dataOnly || !this.options.zone.contains(this.ui.el)) {
             return;
         }
         this.options.zone.removeChild(this.ui.el);

--- a/packages/nipplejs/src/Super.test.ts
+++ b/packages/nipplejs/src/Super.test.ts
@@ -12,6 +12,21 @@ describe('Super', () => {
             expect((instance as any)._handlers_['start'].has(handler)).toBe(true);
         });
 
+        it('on() resolves overload for plain event names without `as any`', () => {
+            const instance = new Super('super');
+            let triggered = false;
+
+            // SuperEventType<T> = T | `${T}${string}` | `${string}${T}` allows plain
+            // event name literals to resolve the correct overload without casting.
+            instance.on('added', () => {
+                triggered = true;
+            });
+
+            instance.trigger('added', instance as any);
+
+            expect(triggered).toBe(true);
+        });
+
         it('on() registers multiple event handlers (comma-separated)', () => {
             const instance = new Super('super');
             const handler = jest.fn();

--- a/packages/nipplejs/src/Super.ts
+++ b/packages/nipplejs/src/Super.ts
@@ -16,7 +16,7 @@ import type {
 } from './types';
 import * as u from './utils';
 
-export type SuperEventType<T extends FactoryEventType> = `${T}${string}` | `${string}${T}`;
+export type SuperEventType<T extends FactoryEventType> = T | `${T}${string}` | `${string}${T}`;
 export type Name = 'super' | 'joystick' | 'collection' | 'factory';
 
 const LOG_LEVELS: Record<LogLevel, number> = {


### PR DESCRIPTION
Hi! 

Thanks so much for the rewrite to TypeScript, it will be much nicer to use now!

Unfortunately when trying to use the new 1.0 release, I came across a few issues:

1. Multiple managers could not each open a joystick at the same time. 
2. The type information for the 'on' event handlers were not working, forcing me to cast it as any.

I built local patches for these and tested these on my production build, but it would of course be preferable to get these issues fixed upstream as well.